### PR TITLE
[User][LCA-7] User 등록/조회/수정/삭제 API 구현 및 Auditing 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,26 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	
+	// ✅ 요청바디 검증용( @NotBlank, @Email, @Size 등)
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // ✅ 비밀번호 해시(BCrypt)만 쓸 거라 security-crypto만 추가
+    implementation 'org.springframework.security:spring-security-crypto'
+	
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	
+	// DB를 MariaDB로 바로 붙일 거면 이대로 ㅇㅋ
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	runtimeOnly 'com.h2database:h2'
+
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/lgcns/studify_be/StudifyBeApplication.java
+++ b/src/main/java/com/lgcns/studify_be/StudifyBeApplication.java
@@ -2,13 +2,12 @@ package com.lgcns.studify_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+@EnableJpaAuditing
+@SpringBootApplication
 public class StudifyBeApplication {
-
-	public static void main(String[] args) {
-		SpringApplication.run(StudifyBeApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(StudifyBeApplication.class, args);
+    }
 }

--- a/src/main/java/com/lgcns/studify_be/common/BaseTimeEntity.java
+++ b/src/main/java/com/lgcns/studify_be/common/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.lgcns.studify_be.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/lgcns/studify_be/config/SecurityBeans.java
+++ b/src/main/java/com/lgcns/studify_be/config/SecurityBeans.java
@@ -1,0 +1,11 @@
+package com.lgcns.studify_be.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityBeans {
+    @Bean public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
+}

--- a/src/main/java/com/lgcns/studify_be/user/User.java
+++ b/src/main/java/com/lgcns/studify_be/user/User.java
@@ -1,0 +1,35 @@
+package com.lgcns.studify_be.user;
+
+import com.lgcns.studify_be.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "users",
+    indexes = { @Index(name = "uk_users_email", columnList = "email", unique = true) }
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class User extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255, unique = true)
+    private String email;
+
+    @Column(nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(length = 50)
+    private String nickname;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status = UserStatus.ACTIVE;
+
+    private LocalDateTime lastLoginAt;
+}

--- a/src/main/java/com/lgcns/studify_be/user/UserController.java
+++ b/src/main/java/com/lgcns/studify_be/user/UserController.java
@@ -1,0 +1,48 @@
+package com.lgcns.studify_be.user;
+
+import com.lgcns.studify_be.user.dto.UserDtos;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService service;
+
+    @PostMapping
+    public ResponseEntity<UserDtos.Response> create(@Valid @RequestBody UserDtos.Create req) {
+        User u = service.create(req);
+        return ResponseEntity
+                .created(java.net.URI.create("/api/users/" + u.getId()))
+                .body(toRes(u));
+    }
+
+    @GetMapping("/{id}")
+    public UserDtos.Response get(@PathVariable Long id) { return toRes(service.get(id)); }
+
+    @PutMapping("/{id}")
+    public UserDtos.Response update(@PathVariable Long id, @Valid @RequestBody UserDtos.Update req) {
+        return toRes(service.update(id, req));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) { service.delete(id); }
+
+    @GetMapping
+    public Page<UserDtos.Response> list(@RequestParam(defaultValue = "0") int page,
+                                        @RequestParam(defaultValue = "10") int size) {
+        return service.list(PageRequest.of(page, size)).map(this::toRes);
+    }
+
+    private UserDtos.Response toRes(User u) {
+        return new UserDtos.Response(
+                u.getId(), u.getEmail(), u.getNickname(), u.getStatus(),
+                u.getLastLoginAt(), u.getCreatedAt(), u.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/lgcns/studify_be/user/UserRepository.java
+++ b/src/main/java/com/lgcns/studify_be/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.lgcns.studify_be.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/lgcns/studify_be/user/UserService.java
+++ b/src/main/java/com/lgcns/studify_be/user/UserService.java
@@ -1,0 +1,45 @@
+package com.lgcns.studify_be.user;
+
+import com.lgcns.studify_be.user.dto.UserDtos;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service @RequiredArgsConstructor
+public class UserService {
+    private final UserRepository repo;
+    private final PasswordEncoder encoder;
+
+    @Transactional
+    public User create(UserDtos.Create dto) {
+        if (repo.existsByEmail(dto.email())) throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        User u = User.builder()
+                .email(dto.email())
+                .passwordHash(encoder.encode(dto.password()))
+                .nickname(dto.nickname())
+                .status(UserStatus.ACTIVE)
+                .build();
+        return repo.save(u);
+    }
+
+    @Transactional(readOnly = true)
+    public User get(Long id) {
+        return repo.findById(id).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + id));
+    }
+
+    @Transactional
+    public User update(Long id, UserDtos.Update dto) {
+        User u = get(id);
+        if (dto.nickname() != null) u.setNickname(dto.nickname());
+        if (dto.status() != null)   u.setStatus(dto.status());
+        if (dto.password() != null) u.setPasswordHash(encoder.encode(dto.password()));
+        return u; // 더티체킹
+    }
+
+    @Transactional public void delete(Long id) { repo.delete(get(id)); }
+
+    @Transactional(readOnly = true)
+    public Page<User> list(Pageable pageable) { return repo.findAll(pageable); }
+}

--- a/src/main/java/com/lgcns/studify_be/user/UserStatus.java
+++ b/src/main/java/com/lgcns/studify_be/user/UserStatus.java
@@ -1,0 +1,5 @@
+package com.lgcns.studify_be.user;
+
+public enum UserStatus {
+    ACTIVE, SUSPENDED, DELETED
+}

--- a/src/main/java/com/lgcns/studify_be/user/dto/UserDtos.java
+++ b/src/main/java/com/lgcns/studify_be/user/dto/UserDtos.java
@@ -1,0 +1,22 @@
+package com.lgcns.studify_be.user.dto;
+
+import com.lgcns.studify_be.user.UserStatus;
+import jakarta.validation.constraints.*;
+import java.time.LocalDateTime;
+
+public class UserDtos {
+    public record Create(
+            @Email @NotBlank String email,
+            @NotBlank @Size(min=8, max=64) String password,
+            @Size(max=50) String nickname
+    ) {}
+    public record Update(
+            @Size(max=50) String nickname,
+            UserStatus status,
+            @Size(min=8, max=64) String password
+    ) {}
+    public record Response(
+            Long id, String email, String nickname, UserStatus status,
+            LocalDateTime lastLoginAt, LocalDateTime createdAt, LocalDateTime updatedAt
+    ) {}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+    open-in-view: false
+
+  h2:
+    console:
+      enabled: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
What
User 등록/조회/수정/삭제 API 구현
UserStatus enum, UserDtos 추가
BaseTimeEntity 적용 (createdAt/updatedAt 자동 반영)

How
JPA & Validation(@Email, @NotBlank, @Size) 적용
PasswordEncoder(BCrypt) Bean 등록
@EnableJpaAuditing 설정
build.gradle: validation, security 의존성 추가

Test
로컬 H2 DB 환경에서 CRUD 동작 확인
POST /api/users 회원생성
GET /api/users/{id} 회원(단건)조회
PUT /api/users/{id} 회원수정
DELETE /api/users/{id} 회원삭제

Impact
BaseTimeEntity로 생성/수정일 자동 반영
다른 도메인 영향 없음